### PR TITLE
refactor: 함수 호출 위치 변경

### DIFF
--- a/packages/core/src/utils/streakHelper.ts
+++ b/packages/core/src/utils/streakHelper.ts
@@ -4,7 +4,7 @@ import type { ResultDate, SortingDateProps } from '../types';
 const stringRange: string[] = [];
 
 function getRange(start: Date | number, end: Date | number) {
-  return eachDayOfInterval({ start, end })
+  changeFormatRange(eachDayOfInterval({ start, end }));
 }
 
 function changeFormatRange(range: Date[]) {
@@ -56,8 +56,7 @@ function putRangeDate(array: Map<string, ResultDate[]>) {
 }
 
 function createDate(start: Date | number, end: Date | number, Date: SortingDateProps[]) {
-  const range = getRange(start, end)
-  changeFormatRange(range)
+  getRange(start, end)
   const sortedData = sortForDate(Date)
   const mapData = changeFormatDate(sortedData)
 	const map = sumAmountByType(mapData)


### PR DESCRIPTION
### 반영 브랜치

feat/get-range -> main

### 변경 사항

getRange()의 내용을 아래와 같이 일부 수정했습니다

* 1번 (getRange) : return 삭제 + 1.2번 함수 호출 (changeFormatDate) 추가

  * 1.2번 함수는 내부에서 날짜 포맷팅을 담당하고 있는 함수이기 때문에, 외부에서 호출될 필요 없이 
  1번 함수에서 생성한 배열을 바로 넘기면서 1.2번 함수를 호출하는 쪽이 더 적절할 것 같습니다!!

createDate()의 내용을 아래와 같이 일부 수정했습니다

* 이전: getRange()의 반환 값을 받아서 range에 저장, 이를 changeFormatRange()의 인자로 넣고 호출
현재: getRange() 호출만 남김

### 테스트 결과

함수 내용은 바뀐 부분이 없어서 테스트 결과는 https://github.com/Soongsil-Developers/streak/pull/10 와 동일합니다

### Issue

#1
