### PR TITLE
chore: date 포맷팅 형식 변경

### DIFF
--- a/packages/core/src/utils/streakHelper.ts
+++ b/packages/core/src/utils/streakHelper.ts
@@ -9,14 +9,14 @@ function getRange(start: Date | number, end: Date | number) {
 
 function changeFormatRange(range: Date[]) {
   range.forEach((yyyymmdd) =>
-      stringRange.push(format(yyyymmdd, 'YYYYMMDD'))
+      stringRange.push(format(yyyymmdd, 'yyyyMMdd'))
   )
 }
 
 function changeFormatDate(dates: SortingDateProps[]) {
   const map = new Map<string, ResultDate[]>();
   dates.forEach((date) => {
-    const key = format(date.date, 'YYYYMMDD');
+    const key = format(date.date, 'yyyyMMdd');
     const value: ResultDate = { type: date.type, amount: date.amount };
     if (map.has(key)) map.get(key)?.push(value);
     else map.set(key, [value]);


### PR DESCRIPTION
### 반영 브랜치

date-format-change -> main

### 변경 사항

date-fns 라이브러리의 format() 을 사용하는 코드에서 날짜 형식을 아래와 같이 변경했습니다

* YYYYMMDD ➡ yyyyMMdd

  * YYYYMMDD 로 형식을 지정할 경우 에러가 발생합니다

  ![yyyy](https://user-images.githubusercontent.com/87255462/188308062-7eb01f63-0894-498a-b47e-db3321aa10be.png)
  ![dd](https://user-images.githubusercontent.com/87255462/188308063-be12d0e6-e881-484a-aef4-4e0576375a54.png)

  * https://github.com/date-fns/date-fns/issues/786 를 참고했습니다
### 테스트 결과


### Issue

#1
