### PR TITLE
feat: 잔디밭 내부 데이터 구현

### DIFF
--- a/packages/streak/src/components/Grass/index.stories.tsx
+++ b/packages/streak/src/components/Grass/index.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import Grass from './index';
+
+export default {
+  title: '잔디밭',
+  component: Grass,
+  parameters: {
+    componentSubtitle: 'Grass 컴포넌트',
+  },
+};
+
+export const defaultButton = () => {
+  return (
+    <Grass
+      data={[
+        { date: new Date(2022, 8, 10), type: '중앙도서관', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '정보과학관', amount: 60 },
+      ]}
+    ></Grass>
+  );
+};
+
+export const three = () => {
+  return (
+    <Grass
+      data={[
+        { date: new Date(2022, 8, 10), type: '중앙도서관', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '정보과학관', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '중앙도서', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '정보과학', amount: 60 },
+      ]}
+    ></Grass>
+  );
+};
+
+export const four = () => {
+  return (
+    <Grass
+      data={[
+        { date: new Date(2022, 8, 10), type: '중앙도서관', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '정보과학관', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '중앙도서', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '정보과학', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '한경직기념관', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '정보학', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '한경직기관', amount: 23 },
+      ]}
+    ></Grass>
+  );
+};
+
+export const five = () => {
+  return (
+    <Grass
+      data={[
+        { date: new Date(2022, 8, 10), type: '1', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '2', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '3', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '4', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '5', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '6', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '7', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '8', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '9', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '10', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '11', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '12', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '13', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '14', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '15', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '16', amount: 23 },
+      ]}
+    ></Grass>
+  );
+};
+
+export const special = () => {
+  return (
+    <Grass
+      data={[
+        { date: new Date(2022, 8, 10), type: '1', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '2', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '3', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '4', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '5', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '6', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '7', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '8', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '9', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '10', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '11', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '12', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '13', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '14', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '15', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '16', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '17', amount: 37 },
+        { date: new Date(2022, 8, 10), type: '18', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '19', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '20', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '21', amount: 23 },
+        { date: new Date(2022, 8, 10), type: '22', amount: 60 },
+        { date: new Date(2022, 8, 10), type: '23', amount: 23 },
+      ]}
+    ></Grass>
+  );
+};

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -50,7 +50,7 @@ const Grass: React.FC<Props> = ({ data }) => {
 
   const isMonthStart = (date: String) => {
     if (date.substring(date.length - 2) === '01') return true;
-    else return false;
+    return false;
   };
 
   const clickDay = (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -54,7 +54,7 @@ const Grass: React.FC<Props> = ({ data }) => {
   };
 
   const clickDay = (e: React.MouseEvent<HTMLElement>) => {
-    if (e.target instanceof HTMLElement)
+    if (e.target instanceof Element)
       result.get(e.target.id)?.map((item) => console.log(item.type));
   };
 

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import createDate, { SortingDateProps, ResultDate } from '../../utils/core';
+
+export interface Props {
+  data: SortingDateProps[];
+}
+
+const Grass: React.FC<Props> = ({ data }) => {
+  let result = new Map<string, ResultDate[]>();
+
+  const getStreakHelperResult = () => {
+    const end = new Date();
+    const start = new Date(
+      new Date().setFullYear(
+        end.getFullYear() - 1,
+        end.getMonth(),
+        end.getDate() + 1
+      )
+    );
+
+    result = createDate(start, end, data);
+    console.log(result);
+
+    const array = Array.from(result, ([date, value]) => ({ date, value }));
+    console.log(array);
+    return array;
+  };
+
+  const getGrassColor = (length: number) => {
+    switch (true) {
+      case length === 0:
+        return { fill: 'grey', opacity: '0.2' };
+
+      case length > 0 && length <= 2:
+        return { fill: 'green', opacity: '0.25' };
+
+      case length > 2 && length <= 6:
+        return { fill: 'green', opacity: '0.4' };
+
+      case length > 6 && length <= 15:
+        return { fill: 'green', opacity: '0.6' };
+
+      case length > 15 && length <= 22:
+        return { fill: 'green', opacity: '1' };
+
+      case length > 22:
+        return { fill: 'red', opacity: '1' };
+    }
+  };
+
+  const isMonthStart = (date: String) => {
+    if (date.substring(date.length - 2) === '01') return true;
+    else return false;
+  };
+
+  const clickDay = (e: React.MouseEvent<HTMLElement>) => {
+    if (e.target instanceof HTMLElement)
+      result.get(e.target.id)?.map((item) => console.log(item.type));
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          height: '220px',
+          display: 'flex',
+          flexDirection: 'column',
+          flexWrap: 'wrap',
+        }}
+      >
+        {getStreakHelperResult().map((data, index) => (
+          <span key={index} onClick={clickDay}>
+            <svg style={{ width: '25', height: '25' }}>
+              <rect
+                id={data.date}
+                width={20}
+                height={20}
+                rx="5"
+                ry="5"
+                style={getGrassColor(data.value.length)}
+              />
+              {isMonthStart(data.date) && (
+                <text x="2" y="15" fontSize={13}>
+                  {data.date.substring(
+                    data.date.length - 4,
+                    data.date.length - 2
+                  )}
+                </text>
+              )}
+            </svg>
+          </span>
+        ))}
+      </div>
+      <div></div>
+    </>
+  );
+};
+
+export default Grass;


### PR DESCRIPTION
### 반영 브랜치

feature/grass -> main

### 변경 사항

잔디밭 내부 데이터 처리에 관한 함수, 테스트 스토리를 추가했습니다!!

getStreakHelperResult() : 오늘 날짜로부터 1년 전 날짜를 구하고, streakhelper를 사용하는 함수

getGrassColor() : 건물 개수에 따라 채도를 다르게 처리하는 함수

isMonthStart() : 해당 날짜가 1일인지 체크하는 함수

clickDay() : 날짜 하나 클릭 시 콘솔에 건물 목록 출력하는 함수

### 테스트 결과

테스트 케이스는 건물 개수에 따라 나누었습니다 (0~5단계 / 특별한(?) 색상은 일단 빨간색으로,,,,, 해뒀어요 ㅎ ㅎ)
월 마다 잔디밭 아래에 표시하는 걸 아직 못 해서 일단 그 칸 안에 몇 월 시작하는지 표시했습니다..!

![가로가로](https://user-images.githubusercontent.com/87255462/189538350-5d0aa5db-ca31-4907-bfb6-7fdcaa7d96d7.gif)

날짜 한 개 클릭하면 콘솔에 건물 목록을 출력합니다 (없으면 안 함)

![가로가로](https://user-images.githubusercontent.com/87255462/189538669-99184e17-0c64-4df5-a71b-635170d5a978.gif)


### Issue

resolve #25
