### PR TITLE
feat: 잔디밭 UI 구현

### DIFF
--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -8,7 +8,7 @@ export interface Props {
 const Grass: React.FC<Props> = ({ data }) => {
   let result = new Map<string, ResultDate[]>();
 
-  const getStreakHelperResult = () => {
+  const getStreakHelperResult = useMemo(() => {
     const end = new Date();
     const start = new Date(
       new Date().setFullYear(
@@ -22,7 +22,7 @@ const Grass: React.FC<Props> = ({ data }) => {
 
     const array = Array.from(result, ([date, value]) => ({ date, value }));
     return array;
-  };
+  }, [data]);
 
   const getGrassColor = (length: number) => {
     switch (true) {
@@ -87,7 +87,7 @@ const Grass: React.FC<Props> = ({ data }) => {
   };
 
   const createGrass = () => {
-    const range = getStreakHelperResult();
+    const range = getStreakHelperResult;
     let rectArr: React.ReactNode[] = [];
     let textArr: React.ReactNode[] = [];
     let x = 10;
@@ -97,17 +97,6 @@ const Grass: React.FC<Props> = ({ data }) => {
     let count = 0; // 7일마다 다음 줄로 넘어가게 해주기 위한 변수
 
     range.forEach((el, index) => {
-      const fill = useMemo(() => {
-        return getGrassColor(el.value.length)
-      }, [el.value])
-
-      const monthString = useMemo(() => {
-        return getMonth(el.date.substring(
-          el.date.length - 4,
-          el.date.length - 2
-        ))
-      }, [el.date])
-       
       if(count % 7 === 0) {
         x += 20;
       }
@@ -119,7 +108,7 @@ const Grass: React.FC<Props> = ({ data }) => {
             width, height,
             x, y: y + (20 * (count % 7)),
             rx: 4, ry: 4,
-            fill: fill,
+            fill: getGrassColor(el.value.length),
             strokeWidth: 2.5,
             stroke: "#fff",
             key: index,
@@ -132,7 +121,10 @@ const Grass: React.FC<Props> = ({ data }) => {
       if(isMonthStart(el.date)) {
         textArr.push(
           <text x={x} y={163} fontSize={14} key={el.date} >
-            {monthString}
+            {getMonth(el.date.substring(
+              el.date.length - 4,
+              el.date.length - 2
+            ))}
           </text>
         )
       };

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -122,7 +122,7 @@ const Grass: React.FC<Props> = ({ data }) => {
 
       if(isMonthStart(el.date)) {
         textArr.push(
-          <text x={x} y={170} >
+          <text x={x} y={163} fontSize={14} >
             {getMonth(el.date.substring(
               el.date.length - 4,
               el.date.length - 2

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -118,7 +118,7 @@ const Grass: React.FC<Props> = ({ data }) => {
             onClick: clickDay,
           }
         )
-      )
+      );
 
       if(isMonthStart(el.date)) {
         textArr.push(
@@ -129,17 +129,16 @@ const Grass: React.FC<Props> = ({ data }) => {
             ))}
           </text>
         )
-      }
+      };
 
       count += 1;
     })
 
     const svgArr: React.ReactNode = React.createElement('svg', { width: 2000, height: 200, background: "#fff" }, [...rectArr, ...textArr])
-    return svgArr
+    return svgArr;
   }
   
   const svgList = makeGrass();
-  console.log(svgList)
 
   return (
     <>

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -29,24 +29,53 @@ const Grass: React.FC<Props> = ({ data }) => {
   const getGrassColor = (length: number) => {
     switch (true) {
       case length === 0:
-        return { fill: 'grey', opacity: '0.2' };
+        return 'hsl(0, 0%, 80%)';
 
       case length > 0 && length <= 2:
-        return { fill: 'green', opacity: '0.25' };
+        return 'hsl(0, 100%, 85%)';
 
       case length > 2 && length <= 6:
-        return { fill: 'green', opacity: '0.4' };
+        return 'hsl(0, 100%, 75%)';
 
       case length > 6 && length <= 15:
-        return { fill: 'green', opacity: '0.6' };
+        return 'hsl(0, 100%, 65%)';
 
       case length > 15 && length <= 22:
-        return { fill: 'green', opacity: '1' };
+        return 'hsl(0, 100%, 50%)';
 
       case length > 22:
-        return { fill: 'red', opacity: '1' };
+        return 'hsl(210, 100%, 70%)';
     }
   };
+
+  const getMonth = (month: String) => {
+    switch(month) {
+      case '01':
+        return 'JAN';
+      case '02':
+        return 'FEB';
+      case '03':
+        return 'MAR';
+      case '04':
+        return 'APR';
+      case '05':
+        return 'MAY';
+      case '06':
+        return 'JUN';
+      case '07':
+        return 'JUL';
+      case '08':
+        return 'AUG';
+      case '09':
+        return 'SEP';
+      case '10':
+        return 'OCT';
+      case '11':
+        return 'NOV';
+      case '12':
+        return 'DEC';
+    }
+  }
 
   const isMonthStart = (date: String) => {
     if (date.substring(date.length - 2) === '01') return true;
@@ -54,9 +83,63 @@ const Grass: React.FC<Props> = ({ data }) => {
   };
 
   const clickDay = (e: React.MouseEvent<HTMLElement>) => {
-    if (e.target instanceof Element)
+    if (e.target instanceof Element) {
       result.get(e.target.id)?.map((item) => console.log(item.type));
+    }
   };
+
+  const makeGrass = () => {
+    const range = getStreakHelperResult();
+    let rectArr: React.ReactNode[] = [];
+    let textArr: React.ReactNode[] = [];
+    let x = 10;
+    let y = 10;
+    let width = 15;
+    let height = 15;
+    let count = 0; // 7일마다 다음 줄로 넘어가게 해주기 위한 변수
+
+    range.forEach((el, index) => {
+      if(count % 7 === 0) {
+        x += 20;
+      }
+
+      rectArr.push(
+        React.createElement(
+          'rect',
+          { 
+            width, height,
+            x, y: y + (20 * (count % 7)),
+            rx: 4, ry: 4,
+            fill: getGrassColor(el.value.length),
+            strokeWidth: 2.5,
+            stroke: "#fff",
+            key: index,
+            id: el.date,
+            onClick: clickDay,
+          }
+        )
+      )
+
+      if(isMonthStart(el.date)) {
+        textArr.push(
+          <text x={x} y={170} >
+            {getMonth(el.date.substring(
+              el.date.length - 4,
+              el.date.length - 2
+            ))}
+          </text>
+        )
+      }
+
+      count += 1;
+    })
+
+    const svgArr: React.ReactNode = React.createElement('svg', { width: 2000, height: 200, background: "#fff" }, [...rectArr, ...textArr])
+    return svgArr
+  }
+  
+  const svgList = makeGrass();
+  console.log(svgList)
 
   return (
     <>
@@ -68,30 +151,8 @@ const Grass: React.FC<Props> = ({ data }) => {
           flexWrap: 'wrap',
         }}
       >
-        {getStreakHelperResult().map((data, index) => (
-          <span key={index} onClick={clickDay}>
-            <svg style={{ width: '25', height: '25' }}>
-              <rect
-                id={data.date}
-                width={20}
-                height={20}
-                rx="5"
-                ry="5"
-                style={getGrassColor(data.value.length)}
-              />
-              {isMonthStart(data.date) && (
-                <text x="2" y="15" fontSize={13}>
-                  {data.date.substring(
-                    data.date.length - 4,
-                    data.date.length - 2
-                  )}
-                </text>
-              )}
-            </svg>
-          </span>
-        ))}
+      {svgList}
       </div>
-      <div></div>
     </>
   );
 };

--- a/packages/streak/src/components/Grass/index.tsx
+++ b/packages/streak/src/components/Grass/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import createDate, { SortingDateProps, ResultDate } from '../../utils/core';
 
 export interface Props {
@@ -19,10 +19,8 @@ const Grass: React.FC<Props> = ({ data }) => {
     );
 
     result = createDate(start, end, data);
-    console.log(result);
 
     const array = Array.from(result, ([date, value]) => ({ date, value }));
-    console.log(array);
     return array;
   };
 
@@ -88,7 +86,7 @@ const Grass: React.FC<Props> = ({ data }) => {
     }
   };
 
-  const makeGrass = () => {
+  const createGrass = () => {
     const range = getStreakHelperResult();
     let rectArr: React.ReactNode[] = [];
     let textArr: React.ReactNode[] = [];
@@ -99,6 +97,17 @@ const Grass: React.FC<Props> = ({ data }) => {
     let count = 0; // 7일마다 다음 줄로 넘어가게 해주기 위한 변수
 
     range.forEach((el, index) => {
+      const fill = useMemo(() => {
+        return getGrassColor(el.value.length)
+      }, [el.value])
+
+      const monthString = useMemo(() => {
+        return getMonth(el.date.substring(
+          el.date.length - 4,
+          el.date.length - 2
+        ))
+      }, [el.date])
+       
       if(count % 7 === 0) {
         x += 20;
       }
@@ -110,7 +119,7 @@ const Grass: React.FC<Props> = ({ data }) => {
             width, height,
             x, y: y + (20 * (count % 7)),
             rx: 4, ry: 4,
-            fill: getGrassColor(el.value.length),
+            fill: fill,
             strokeWidth: 2.5,
             stroke: "#fff",
             key: index,
@@ -122,11 +131,8 @@ const Grass: React.FC<Props> = ({ data }) => {
 
       if(isMonthStart(el.date)) {
         textArr.push(
-          <text x={x} y={163} fontSize={14} >
-            {getMonth(el.date.substring(
-              el.date.length - 4,
-              el.date.length - 2
-            ))}
+          <text x={x} y={163} fontSize={14} key={el.date} >
+            {monthString}
           </text>
         )
       };
@@ -137,8 +143,6 @@ const Grass: React.FC<Props> = ({ data }) => {
     const svgArr: React.ReactNode = React.createElement('svg', { width: 2000, height: 200, background: "#fff" }, [...rectArr, ...textArr])
     return svgArr;
   }
-  
-  const svgList = makeGrass();
 
   return (
     <>
@@ -150,7 +154,7 @@ const Grass: React.FC<Props> = ({ data }) => {
           flexWrap: 'wrap',
         }}
       >
-      {svgList}
+      {createGrass()}
       </div>
     </>
   );


### PR DESCRIPTION
### 반영 브랜치

feat/add-grass-ui -> main

### 변경 사항

유진님 코드랑 연결해서 type 수에 따라 채도 다르게 하는 부분과 잔디밭 밑에 월 표시하는 부분 구현했습니다!
getMonth() : month 숫자를 보고 month 문자열을 가져오는 함수 (ex. '01' 이면 'JAN' 을 리턴)
makeGrass() : 잔디밭 ui 만들어주는 함수 (svg - rect, text)

### 테스트 결과

![image](https://user-images.githubusercontent.com/50830078/189679775-682ddf59-a1e1-46a1-bd48-6cdd6a4afceb.png)
↑ 폰트 크기/간격 수정 전

![image](https://user-images.githubusercontent.com/50830078/189691820-0080ec70-d0db-4d24-af32-884e453a8434.png)
↑ 폰트 크기/간격 수정 후 

